### PR TITLE
[VEN-2258]: add TimeManagerV5 and TimeManagerV8

### DIFF
--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -18,7 +18,7 @@ contract TimeManagerV5 {
     function() view returns (uint256) private _getCurrentSlot;
 
     /**
-     * @param timeBased_ A boolean indicating whether the contract is based on time or block.
+     * @param timeBased_ A boolean indicating whether the contract is based on time or block
      * If timeBased is true than blocksPerYear_ param is ignored as blocksOrSecondsPerYear is set to SECONDS_PER_YEAR
      * @param blocksPerYear_ The number of blocks per year
      */
@@ -27,7 +27,7 @@ contract TimeManagerV5 {
             revert("Invalid blocks per year");
         }
         if (timeBased_ && blocksPerYear_ != 0) {
-            revert("Invalid time based");
+            revert("Invalid time based configuration");
         }
 
         isTimeBased = timeBased_;
@@ -44,7 +44,7 @@ contract TimeManagerV5 {
     }
 
     /**
-     * @notice Returns the current timestamp in seconds
+     * @dev Returns the current timestamp in seconds
      * @return The current timestamp
      */
     function _getBlockTimestamp() private view returns (uint256) {
@@ -52,7 +52,7 @@ contract TimeManagerV5 {
     }
 
     /**
-     * @notice Returns the current block number
+     * @dev Returns the current block number
      * @return The current block number
      */
     function _getBlockNumber() private view returns (uint256) {

--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.5.16;
+
+contract TimeManagerV5 {
+    /// @dev The approximate number of seconds per year
+    uint256 public constant SECONDS_PER_YEAR = 31_536_000;
+
+    /// @notice Number of blocks per year or seconds per year
+    uint256 public blocksOrSecondsPerYear;
+
+    /// @dev Sets true when block timestamp is used
+    bool public isTimeBased;
+
+    /**
+     * @dev Retrieves the current slot
+     * @return Current slot
+     */
+    function() view returns (uint256) private _getCurrentSlot;
+
+    /**
+     * @param timeBased_ A boolean indicating whether the contract is based on time or block.
+     * If timeBased is true than blocksPerYear_ param is ignored as blocksOrSecondsPerYear is set to SECONDS_PER_YEAR
+     * @param blocksPerYear_ The number of blocks per year
+     */
+    constructor(bool timeBased_, uint256 blocksPerYear_) public {
+        if (!timeBased_ && blocksPerYear_ == 0) {
+            revert("Invalid Blocks Per year");
+        }
+        isTimeBased = timeBased_;
+        blocksOrSecondsPerYear = timeBased_ ? SECONDS_PER_YEAR : blocksPerYear_;
+        _getCurrentSlot = timeBased_ ? _getBlockTimestamp : _getBlockNumber;
+    }
+
+    /**
+     * @dev Function to simply retrieve block number or block timestamp
+     *  This exists mainly for inheriting test contracts to stub this result.
+     * @return Current block number or block timestamp
+     */
+    function getBlockNumberOrTimestamp() public view returns (uint256) {
+        return _getCurrentSlot();
+    }
+
+    /**
+     * @notice Returns the current timestamp in seconds
+     * @return The current timestamp
+     */
+    function _getBlockTimestamp() private view returns (uint256) {
+        return block.timestamp;
+    }
+
+    /**
+     * @notice Returns the current block number
+     * @return The current block number
+     */
+    function _getBlockNumber() private view returns (uint256) {
+        return block.number;
+    }
+}

--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -12,6 +12,13 @@ contract TimeManagerV5 {
     bool public isTimeBased;
 
     /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[47] private __gap;
+
+    /**
      * @dev Retrieves the current slot
      * @return Current slot
      */

--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -24,8 +24,12 @@ contract TimeManagerV5 {
      */
     constructor(bool timeBased_, uint256 blocksPerYear_) public {
         if (!timeBased_ && blocksPerYear_ == 0) {
-            revert("Invalid Blocks Per year");
+            revert("Invalid blocks per year");
         }
+        if (timeBased_ && blocksPerYear_ != 0) {
+            revert("Invalid time based");
+        }
+
         isTimeBased = timeBased_;
         blocksOrSecondsPerYear = timeBased_ ? SECONDS_PER_YEAR : blocksPerYear_;
         _getCurrentSlot = timeBased_ ? _getBlockTimestamp : _getBlockNumber;
@@ -33,7 +37,6 @@ contract TimeManagerV5 {
 
     /**
      * @dev Function to simply retrieve block number or block timestamp
-     *  This exists mainly for inheriting test contracts to stub this result.
      * @return Current block number or block timestamp
      */
     function getBlockNumberOrTimestamp() public view returns (uint256) {

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 import { SECONDS_PER_YEAR } from "./constants.sol";
 
-abstract contract TimeManager {
+abstract contract TimeManagerV8 {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     uint256 public immutable blocksOrSecondsPerYear;
 

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -10,6 +10,13 @@ abstract contract TimeManagerV8 {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     bool public immutable isTimeBased;
 
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[48] private __gap;
+
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     function() view returns (uint256) private immutable _getCurrentSlot;
 

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -17,13 +17,14 @@ abstract contract TimeManagerV8 {
     error InvalidBlocksPerYear();
 
     /// @notice Thrown when time based but blocks per year is provided
-    error InvalidTimeBased();
+    error InvalidTimeBasedConfiguration();
 
     /**
-     * @param timeBased_ A boolean indicating whether the contract is based on time or block.
+     * @param timeBased_ A boolean indicating whether the contract is based on time or block
      * If timeBased is true than blocksPerYear_ param is ignored as blocksOrSecondsPerYear is set to SECONDS_PER_YEAR
      * @param blocksPerYear_ The number of blocks per year
-     * @custom:error InvalidBlocksPerYear is thrown if blocksPerYear entered is zero
+     * @custom:error InvalidBlocksPerYear is thrown if blocksPerYear entered is zero and timeBased is false
+     * @custom:error InvalidTimeBasedConfiguration is thrown if blocksPerYear entered is non zero and timeBased is true
      * @custom:oz-upgrades-unsafe-allow constructor
      */
     constructor(bool timeBased_, uint256 blocksPerYear_) {
@@ -32,7 +33,7 @@ abstract contract TimeManagerV8 {
         }
 
         if (timeBased_ && blocksPerYear_ != 0) {
-            revert InvalidTimeBased();
+            revert InvalidTimeBasedConfiguration();
         }
 
         isTimeBased = timeBased_;
@@ -49,7 +50,7 @@ abstract contract TimeManagerV8 {
     }
 
     /**
-     * @notice Returns the current timestamp in seconds
+     * @dev Returns the current timestamp in seconds
      * @return The current timestamp
      */
     function _getBlockTimestamp() private view returns (uint256) {
@@ -57,7 +58,7 @@ abstract contract TimeManagerV8 {
     }
 
     /**
-     * @notice Returns the current block number
+     * @dev Returns the current block number
      * @return The current block number
      */
     function _getBlockNumber() private view returns (uint256) {

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 import { SECONDS_PER_YEAR } from "./constants.sol";
 
-abstract contract TimeManagerV8 {
+abstract contract TimeManager {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     uint256 public immutable blocksOrSecondsPerYear;
 
@@ -13,8 +13,11 @@ abstract contract TimeManagerV8 {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     function() view returns (uint256) private immutable _getCurrentSlot;
 
-    /// @notice Thrown on invaid arguments
+    /// @notice Thrown when blocks per year is invalid
     error InvalidBlocksPerYear();
+
+    /// @notice Thrown when time based but blocks per year is provided
+    error InvalidTimeBased();
 
     /**
      * @param timeBased_ A boolean indicating whether the contract is based on time or block.
@@ -28,6 +31,10 @@ abstract contract TimeManagerV8 {
             revert InvalidBlocksPerYear();
         }
 
+        if (timeBased_ && blocksPerYear_ != 0) {
+            revert InvalidTimeBased();
+        }
+
         isTimeBased = timeBased_;
         blocksOrSecondsPerYear = timeBased_ ? SECONDS_PER_YEAR : blocksPerYear_;
         _getCurrentSlot = timeBased_ ? _getBlockTimestamp : _getBlockNumber;
@@ -35,7 +42,6 @@ abstract contract TimeManagerV8 {
 
     /**
      * @dev Function to simply retrieve block number or block timestamp
-     *  This exists mainly for inheriting test contracts to stub this result.
      * @return Current block number or block timestamp
      */
     function getBlockNumberOrTimestamp() public view virtual returns (uint256) {

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+import { SECONDS_PER_YEAR } from "./constants.sol";
+
+abstract contract TimeManagerV8 {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    uint256 public immutable blocksOrSecondsPerYear;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    bool public immutable isTimeBased;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    function() view returns (uint256) private immutable _getCurrentSlot;
+
+    /// @notice Thrown on invaid arguments
+    error InvalidBlocksPerYear();
+
+    /**
+     * @param timeBased_ A boolean indicating whether the contract is based on time or block.
+     * If timeBased is true than blocksPerYear_ param is ignored as blocksOrSecondsPerYear is set to SECONDS_PER_YEAR
+     * @param blocksPerYear_ The number of blocks per year
+     * @custom:error InvalidBlocksPerYear is thrown if blocksPerYear entered is zero
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor(bool timeBased_, uint256 blocksPerYear_) {
+        if (!timeBased_ && blocksPerYear_ == 0) {
+            revert InvalidBlocksPerYear();
+        }
+
+        isTimeBased = timeBased_;
+        blocksOrSecondsPerYear = timeBased_ ? SECONDS_PER_YEAR : blocksPerYear_;
+        _getCurrentSlot = timeBased_ ? _getBlockTimestamp : _getBlockNumber;
+    }
+
+    /**
+     * @dev Function to simply retrieve block number or block timestamp
+     *  This exists mainly for inheriting test contracts to stub this result.
+     * @return Current block number or block timestamp
+     */
+    function getBlockNumberOrTimestamp() public view virtual returns (uint256) {
+        return _getCurrentSlot();
+    }
+
+    /**
+     * @notice Returns the current timestamp in seconds
+     * @return The current timestamp
+     */
+    function _getBlockTimestamp() private view returns (uint256) {
+        return block.timestamp;
+    }
+
+    /**
+     * @notice Returns the current block number
+     * @return The current block number
+     */
+    function _getBlockNumber() private view returns (uint256) {
+        return block.number;
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,6 +47,22 @@ const config: HardhatUserConfig = {
           },
         },
       },
+      {
+        version: "0.5.16",
+        settings: {
+          optimizer: {
+            enabled: true,
+            details: {
+              yul: !process.env.CI,
+            },
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
+        },
+      },
     ],
   },
   networks: {

--- a/tests/hardhat/TimeManagerV5.ts
+++ b/tests/hardhat/TimeManagerV5.ts
@@ -1,0 +1,34 @@
+import chai from "chai";
+import { ethers } from "hardhat";
+
+const { expect } = chai;
+
+describe("TimeManagerV5: tests", async () => {
+  let timeManager: ethers.Contracts;
+  describe("For block number", async () => {
+    const blocksPerYear = 10512000;
+    beforeEach(async () => {
+      const timeManagerV5 = await ethers.getContractFactory("TimeManagerV5");
+      timeManager = await timeManagerV5.deploy(false, blocksPerYear);
+    });
+
+    it("Retrieves block timestamp", async () => {
+      const currentBlockNumber = (await ethers.provider.getBlock("latest")).number;
+      expect(await timeManager.getBlockNumberOrTimestamp()).to.be.equal(currentBlockNumber);
+      expect(await timeManager.blocksOrSecondsPerYear()).to.be.equal(blocksPerYear);
+    });
+  });
+  describe("For block timestamp", async () => {
+    beforeEach(async () => {
+      const timeManagerV5 = await ethers.getContractFactory("TimeManagerV5");
+      timeManager = await timeManagerV5.deploy(true, 0);
+    });
+
+    it("Retrieves block timestamp", async () => {
+      const secondsPerYear = await timeManager.SECONDS_PER_YEAR();
+      const currentBlocktimestamp = (await ethers.provider.getBlock("latest")).timestamp;
+      expect(await timeManager.getBlockNumberOrTimestamp()).to.be.equal(currentBlocktimestamp);
+      expect(await timeManager.blocksOrSecondsPerYear()).to.be.equal(secondsPerYear);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR contains 2 contracts TimeMangerV5 and TimeManagerV8

- TimeManagerV5 is compatible with solidity version 0.5.16.
- TimeManagerV8 is compatible with solidity version 0.8.13.
- Tested  TimeManagerV5 functionalities.

Resolves VEN-2258

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
