### PR TITLE
feat: migrate to 0.8.20

### DIFF
--- a/contracts/ExponentialNoError.sol
+++ b/contracts/ExponentialNoError.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { EXP_SCALE as EXP_SCALE_, MANTISSA_ONE as MANTISSA_ONE_ } from "./constants.sol";
 

--- a/contracts/MaxLoopsLimitHelper.sol
+++ b/contracts/MaxLoopsLimitHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /**
  * @title MaxLoopsLimitHelper

--- a/contracts/TimeManagerV8.sol
+++ b/contracts/TimeManagerV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SECONDS_PER_YEAR } from "./constants.sol";
 

--- a/contracts/constants.sol
+++ b/contracts/constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /// @dev Base unit for computations, usually used in scaling (multiplications, divisions)
 uint256 constant EXP_SCALE = 1e18;

--- a/contracts/test/HarnessMaxLoopsLimitHelper.sol
+++ b/contracts/test/HarnessMaxLoopsLimitHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { MaxLoopsLimitHelper } from "../MaxLoopsLimitHelper.sol";
 

--- a/contracts/validators.sol
+++ b/contracts/validators.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /// @notice Thrown if the supplied address is a zero address where it is not allowed
 error ZeroAddressNotAllowed();

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.13",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
This PR updates the pragma to:

* `^0.8.20` for interfaces, constants, etc.
* `0.8.20` for anything that contains code