### PR TITLE
chore: specify paris hardfork explicitly

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,6 +38,7 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 200,
           },
+          evmVersion: "paris",
           outputSelection: {
             "*": {
               "*": ["storageLayout"],


### PR DESCRIPTION
Although hardhat uses paris by default for solc >=0.8.20, this might not be the case in future versions of hardhat. It's better to specify the hardfork explicitly, and update it when the chains are ready.