### PR TITLE
TimeManagerV5 remove function pointer and add conditional logic

### DIFF
--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -14,11 +14,8 @@ contract TimeManagerV5 {
     /// @dev Sets true when contract is initialized
     bool private isInitialized;
 
-    /**
-     * @dev Retrieves the current slot
-     * @return Current slot
-     */
-    function() view returns (uint256) private _getCurrentSlot;
+    /// @notice Deprecated slot for _getCurrentSlot function pointer
+    bytes32 private __deprecatedSlot1;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
@@ -32,7 +29,7 @@ contract TimeManagerV5 {
      * @return Current block number or block timestamp
      */
     function getBlockNumberOrTimestamp() public view returns (uint256) {
-        return _getCurrentSlot();
+        return isTimeBased ? _getBlockTimestamp() : _getBlockNumber();
     }
 
     /**
@@ -53,7 +50,6 @@ contract TimeManagerV5 {
 
         isTimeBased = timeBased_;
         blocksOrSecondsPerYear = timeBased_ ? SECONDS_PER_YEAR : blocksPerYear_;
-        _getCurrentSlot = timeBased_ ? _getBlockTimestamp : _getBlockNumber;
         isInitialized = true;
     }
 


### PR DESCRIPTION
## Description

This PR removes the `_getCurrentSlot` function pointer and changes the logic of `getBlockNumberOrTimestamp()` to not refer to `_getCurrentSlot` pointer but to either call `_getBlockTimestamp()` or ` _getBlockNumber()` based on a conditional logic of the `isTimeBased` storage var.


## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
