### PR TITLE
[VEN-2608]: TimeManagerV5 storage fix

### DIFF
--- a/contracts/TimeManagerV5.sol
+++ b/contracts/TimeManagerV5.sol
@@ -15,7 +15,7 @@ contract TimeManagerV5 {
     bool private isInitialized;
 
     /// @notice Deprecated slot for _getCurrentSlot function pointer
-    bytes32 private __deprecatedSlot1;
+    bytes8 private __deprecatedSlot1;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves #VEN-2608
This PR fixes the size of **deprecatedSlot** in TimeManagerV5 from `bytes32` to `bytes8` following old storage.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
